### PR TITLE
Fixed comment

### DIFF
--- a/Chart/ux/Highcharts.js
+++ b/Chart/ux/Highcharts.js
@@ -649,7 +649,9 @@ Ext.define("Chart.ux.Highcharts", {
         }
     },
 
-    //@deprecated
+    /**
+     * @deprecated
+     */
     onContainerResize : function() {
         Ext.log("onContainerResize");
         this.draw();


### PR DESCRIPTION
Hi,

I just downloaded the lastest version of your plugin, and there was a comment (line 652 of Chart/ux/Highcharts.js) **@deprecated** that was behing line comments instead of a doc block, causing IE to break on that line ( Expected ':'  ).

Just fixed that for you :)

Romain
