### PR TITLE
Highcharts are not working in Windows 8.1 with Highcharts_Sencha plugin

### DIFF
--- a/Chart/ux/Highcharts.js
+++ b/Chart/ux/Highcharts.js
@@ -372,7 +372,7 @@ Ext.define("Chart.ux.Highcharts", {
         }
     },
 
-    initComponent : function() {
+    initialize : function() {
         if(this.store) {
             this.store = Ext.data.StoreManager.lookup(this.store);
         }


### PR DESCRIPTION
We need to change Chart.ux.Highcharts initComponent method to initialize 
This is required because initComponent is deprecated.

I have tested this on Android, IOS and Windows.